### PR TITLE
The count() function should return an integer and not a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.idea

--- a/src/LessQL/Result.php
+++ b/src/LessQL/Result.php
@@ -553,7 +553,7 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 	 */
 	function count( $expr = "*" ) {
 
-		return $this->aggregate( "COUNT(" . $expr . ")" );
+		return (int) $this->aggregate( "COUNT(" . $expr . ")" );
 
 	}
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -410,4 +410,11 @@ class ResultTest extends BaseTest {
 
 	}
 
+	function testCountResultIsAnInteger() {
+		$db = self::$db;
+		$expected = count($db->user()->fetchAll());
+		$result = $db->user()->count();
+		$this->assertSame($expected, $result);
+	}
+
 }


### PR DESCRIPTION
A simple cast fixes the problem.
Test added as well.
