### PR TITLE
Keep parameters consistent

### DIFF
--- a/src/LessQL/Result.php
+++ b/src/LessQL/Result.php
@@ -213,7 +213,7 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 	 * @param array $data Row data
 	 * @return Row
 	 */
-	function createRow( $data ) {
+	function createRow( $data = array() ) {
 
 		return $this->db->createRow( $this->table, $data, $this );
 


### PR DESCRIPTION
Just to keep it consistent since the $properties parameter of LessQL\Database::createRow() is optional.
