### PR TITLE
Improving pgsql compatibility

### DIFF
--- a/src/LessQL/Database.php
+++ b/src/LessQL/Database.php
@@ -18,7 +18,7 @@ class Database {
 		$pdo->setAttribute( \PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION );
 		$this->pdo = $pdo;
         if ($this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'pgsql') {
-            $this->setIdentifierDelimiter('');
+            $this->setIdentifierDelimiter('"');
         }
 	}
 

--- a/src/LessQL/Database.php
+++ b/src/LessQL/Database.php
@@ -17,7 +17,9 @@ class Database {
 		// required for safety
 		$pdo->setAttribute( \PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION );
 		$this->pdo = $pdo;
-
+        if ($this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'pgsql') {
+            $this->setIdentifierDelimiter('');
+        }
 	}
 
 	/**


### PR DESCRIPTION
When using `pgsql` with PDO I get this error:
```
In Database.php line 662:
                                                                           
  SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "`"     
  LINE 1: INSERT INTO `users`
```

This is due to the fact that the `$identifierDelimiter` is set to be ``"`"`` by default, I just added an if that checks whether the driver is pgsql and setting it as an empty string in that case.

Let me know if it is ok.