### PR TITLE
HAVING, GROUP BY and JOIN

### DIFF
--- a/src/LessQL/Database.php
+++ b/src/LessQL/Database.php
@@ -497,6 +497,8 @@ class Database {
 			'expr' => null,
 			'where' => array(),
 			'orderBy' => array(),
+			'groupBy' => array(),
+			'having' => array(),
 			'limitCount' => null,
 			'limitOffset' => null,
 			'params' => array()
@@ -520,9 +522,14 @@ class Database {
 		}
 
 		$table = $this->rewriteTable( $table );
-		$query .= " FROM " . $this->quoteIdentifier( $table );
 
-		$query .= $this->getSuffix( $options[ 'where' ], $options[ 'orderBy' ], $options[ 'limitCount' ], $options[ 'limitOffset' ] );
+		if (strpos($table, ' ')!== false){
+			$query .= " FROM " . $table; // Raw table expression for JOINs
+		} else {
+			$query .= " FROM " . $this->quoteIdentifier( $table );
+		}
+
+		$query .= $this->getSuffix( $options[ 'where' ], $options[ 'orderBy' ], $options[ 'groupBy' ], $options[ 'having' ], $options[ 'limitCount' ], $options[ 'limitOffset' ] );
 
 		$this->onQuery( $query, $options[ 'params' ] );
 
@@ -817,7 +824,7 @@ class Database {
 	 * @param int|null $limitOffset
 	 * @return string
 	 */
-	function getSuffix( $where, $orderBy = array(), $limitCount = null, $limitOffset = null ) {
+	function getSuffix( $where, $orderBy = array(), $groupBy = array(), $having = array(), $limitCount = null, $limitOffset = null ) {
 
 		$suffix = "";
 
@@ -830,6 +837,18 @@ class Database {
 		if ( !empty( $orderBy ) ) {
 
 			$suffix .= " ORDER BY " . implode( ", ", $orderBy );
+
+		}
+
+		if ( !empty( $groupBy ) ) {
+
+			$suffix .= " GROUP BY " . implode( ", ", $groupBy );
+
+		}
+
+		if ( !empty( $having ) ) {
+
+			$suffix .= " HAVING " . implode( " AND ", $having );
 
 		}
 

--- a/src/LessQL/Result.php
+++ b/src/LessQL/Result.php
@@ -157,6 +157,8 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 				'expr' => $this->select,
 				'where' => $this->where,
 				'orderBy' => $this->orderBy,
+				'groupBy' => $this->groupBy,
+				'having' => $this->having,
 				'limitCount' => $this->limitCount,
 				'limitOffset' => $this->limitOffset,
 				'params' => $this->whereParams
@@ -637,6 +639,66 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 	}
 
 	/**
+	 * Add GROUP BY condition
+	 *
+	 * @param string $column
+	 * @return $this
+	 */
+	function groupBy( $column ) {
+
+		if ( $this->parent_ ) {
+
+			throw new \LogicException( 'Cannot limit referenced result' );
+
+		}
+
+		$clone = clone $this;
+
+		$clone->groupBy[] = $this->db->quoteIdentifier( $column );
+
+		return $clone;
+
+	}
+
+	/**
+	 * Add a HAVING condition (multiple are combined with AND)
+	 *
+	 * @param string|array $condition
+	 * @param string|array $params
+	 * @return $this
+	 */
+	function having( $condition, $params = array() ) {
+
+		$clone = clone $this;
+
+		// conditions in key-value array
+		if ( is_array( $condition ) ) {
+
+			foreach ( $condition as $c => $params ) {
+
+				$clone = $clone->having( $c, $params );
+
+			}
+
+			return $clone;
+
+		}
+
+		if ( !is_array( $params ) ) {
+
+			$params = func_get_args();
+			array_shift( $params );
+
+		}
+
+		$clone->having[] = $condition;
+		$clone->whereParams = array_merge( $clone->whereParams, $params );
+
+		return $clone;
+
+	}
+
+	/**
 	 * Set a paged limit
 	 * Pages start at 1
 	 *
@@ -719,6 +781,8 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 			'expr' => $function,
 			'where' => $this->where,
 			'orderBy' => $this->orderBy,
+			'groupBy' => $this->groupBy,
+			'having' => $this->having,
 			'limitCount' => $this->limitCount,
 			'limitOffset' => $this->limitOffset,
 			'params' => $this->whereParams
@@ -762,6 +826,8 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 			'where' => $this->where,
 			'whereParams' => $this->whereParams,
 			'orderBy' => $this->orderBy,
+			'groupBy' => $this->groupBy,
+			'having' => $this->having,
 			'limitCount' => $this->limitCount,
 			'limitOffset' => $this->limitOffset
 
@@ -832,6 +898,12 @@ class Result implements \IteratorAggregate, \JsonSerializable {
 
 	/** @var array */
 	protected $orderBy = array();
+
+	/** @var array */
+	protected $groupBy = array();
+
+	/** @var array */
+	protected $having = array();
 
 	/** @var null|int */
 	protected $limitCount;


### PR DESCRIPTION
This patch add initial support for HAVING condition by having() method, GROUP BY condition by orderBy() method. Also if in table() we have expression with spaces, then quoteIdentifier() not apply.

This patch allows something like:
`$q = $db->table('person LEFT JOIN pkl ON person.id = pkl.person_id');`
`$q->select('COUNT(pkl.id) AS events_сount')->groupBy('person.id')->having('events_сount > 0');`