### PR TITLE
Use 'LessQL' namespace for PSR-0 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"autoload": {
 		"psr-0": {
-			"": "src"
+			"LessQL\\": "src"
 		}
 	},
 	"require": {


### PR DESCRIPTION
During some work on [grocy-docker](https://github.com/grocy/grocy-docker), I encountered a strange situation where the PHP application seemed to depend on `composer` being installed on the system at runtime.

The underlying PHP application uses [Slim Framework v4](https://github.com/slimphp/Slim/releases/tag/4.4.0) ([ref](https://github.com/grocy/grocy/blob/master/composer.json#L4)) and LessQL v0.4.1 (current) ([ref](https://github.com/grocy/grocy/blob/master/composer.json#L10)).

The following error occurred during application requests when `composer` was not installed:

```
Slim Application Error

The application could not run because of the following error:
Details
Type: Error
Code: 0
Message: Call to undefined function LessQL\json_encode()
File: /var/www/vendor/morris/lessql/src/LessQL/Result.php
Line: 662
Trace

#0 /var/www/vendor/morris/lessql/src/LessQL/Result.php(137): LessQL\Result->getDefinition()
#1 /var/www/vendor/morris/lessql/src/LessQL/Result.php(322): LessQL\Result->execute()
#2 /var/www/services/SessionService.php(19): LessQL\Result->fetch()
...
#16 /var/www/public/index.php(3): require_once('/var/www/app.ph...')
#17 {main}
```

After looking at the `lessql` source and experimenting in a fork of the repo, it appears that this is due to a [fallback directory configured in composer.json](https://github.com/morris/lessql/blob/master/composer.json#L15).

This leads to an attempt to resolve `json_encode` within the `LessQL` namespace.

This proposed change removes the autoload definition -- although I do notice that the `lessql` codebase has included [backwards compatibility for PHP 5.4](https://github.com/morris/lessql/blob/f4150517f6492a761ed1ccb8dd180769e1f89e54/src/JsonSerializable.php) ([which was supported until Sep 2015](https://en.wikipedia.org/wiki/PHP#Release_history)) since the initial commit.

I'll also experiment with PSR-4 and try to determine whether an upgrade is preferable to this change.