### PR TITLE
Fixed PHP 8.1 deprecation warnings

### DIFF
--- a/src/LessQL/Result.php
+++ b/src/LessQL/Result.php
@@ -649,7 +649,7 @@ class Result implements \IteratorAggregate, \JsonSerializable
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator() : \Traversable
     {
         $this->execute();
 
@@ -699,7 +699,7 @@ class Result implements \IteratorAggregate, \JsonSerializable
      *
      * @return Row[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         return $this->fetchAll();
     }

--- a/src/LessQL/Row.php
+++ b/src/LessQL/Row.php
@@ -613,7 +613,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \JsonSerializable
      * @param string $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return $this->__isset($offset);
     }
@@ -622,7 +622,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \JsonSerializable
      * @param string $offset
      * @return mixed
      */
-    public function &offsetGet($offset)
+    public function &offsetGet($offset) : mixed
     {
         return $this->__get($offset);
     }
@@ -631,7 +631,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \JsonSerializable
      * @param string $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value) : void
     {
         $this->__set($offset, $value);
     }
@@ -639,7 +639,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \JsonSerializable
     /**
      * @param string $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset) : void
     {
         $this->__unset($offset);
     }
@@ -649,7 +649,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \JsonSerializable
     /**
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator() : \Traversable
     {
         return new \ArrayIterator($this->_properties);
     }
@@ -659,7 +659,7 @@ class Row implements \ArrayAccess, \IteratorAggregate, \JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         $array = array();
 


### PR DESCRIPTION
Hi, and first thanks a lot for LessQL!

I've noticed some deprecation warnings when upgrading to PHP 8.1 and fixed them here.